### PR TITLE
Add README usage guide and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,132 @@
+# AGENTS.md
+
+Guidance for AI coding agents (and humans) working in this repository.
+
+## What this project is
+
+`puntodev/bookables` is a small, **framework-agnostic** PHP library for computing
+**bookable availability and time slots**. Given a description of when something is
+available (a weekly schedule or a single date range), it produces concrete date
+ranges and bookable slots within a requested window.
+
+It is a pure domain library: no Laravel/Symfony coupling, no database, no HTTP. It
+is meant to be embedded inside a larger booking/scheduling application.
+
+## Tech stack
+
+- **PHP** `>=8.4 <9.0`, `ext-json`.
+- **Runtime dependencies**
+  - [`nesbot/carbon`](https://carbon.nesbot.com/) `^3.11` — date/time handling.
+  - [`league/period`](https://period.thephpleague.com/) `^5.3` — the `Period`
+    value object used to represent ranges and slots.
+- **Dev dependencies**: `phpunit/phpunit` `^13.2`, `mockery/mockery` `^1.6`.
+- **Autoloading** (PSR-4):
+  - `Puntodev\Bookables\` → `src/`
+  - `Tests\` → `tests/`
+
+## Repository layout
+
+```
+src/
+  WeeklySchedule.php            Value object: recurring weekly availability (JSON/array serializable)
+  Contracts/
+    Agenda.php                  possibleRanges(from, to): Period[]
+    HasAgenda.php               agenda(): Agenda   (marker for bookable entities)
+    TimeSlotter.php             makeSlotsForDates(start, end): Period[]
+    TimeBookable.php            available()/unavailable()  (for consumers to implement)
+  Agenda/
+    WeeklyScheduleAgenda.php    Agenda backed by a WeeklySchedule
+    SingleDateRangeAgenda.php   Agenda for a single fixed start/end range
+  Slots/
+    AgendaSlotter.php           Slices an Agenda's ranges into fixed-duration slots
+    DaySlotter.php              Sliding-window slots across the whole day (ignores agenda)
+tests/
+  Agenda/WeeklyScheduleAgendaTest.php
+  Slots/AgendaSlotterTest.php
+  Slots/DaySlotterTest.php
+  WeeklyScheduleUnitTest.php
+  Concerns/WithRangeAssertions.php   assertRanges() helper (compares Period::toIso8601())
+```
+
+## Core concepts and data flow
+
+The typical pipeline is **schedule → agenda → slotter → slots**:
+
+1. **`WeeklySchedule`** describes recurring weekly availability. Construction is
+   only via the static factories — the constructor is `private`:
+   - `WeeklySchedule::fromArray(array)` / `WeeklySchedule::fromJson(string)` —
+     both run `validate()` and **throw a plain `\Exception`** on malformed input.
+   - `WeeklySchedule::defaultWorkingHours()` returns a sample array (Mon–Fri
+     08:00–12:00 & 14:00–18:00, Sat 10:00–12:00).
+   - Fields: `daily` (per day-of-week `Sun`..`Sat`, each a list of
+     `{start, end}` `HH:MM` ranges), `hours_in_advance` (int), `disable_all` (bool).
+   - `forDate(CarbonInterface)` / `forDay(string)` return that day's ranges, or
+     `[]` when `disable_all` is true.
+2. **`Agenda::possibleRanges(from, to)`** turns availability into concrete
+   `League\Period\Period[]` clamped to the `[from, to]` window.
+   - `WeeklyScheduleAgenda` iterates each day in the window and emits one `Period`
+     per matching schedule range.
+   - `SingleDateRangeAgenda` emits at most one `Period` (the intersection of its
+     fixed range with the window).
+3. **`TimeSlotter::makeSlotsForDates(start, end)`** chops ranges into bookable
+   slots (also `Period[]`).
+   - `AgendaSlotter(Agenda $agenda, int $duration, int $timeAfter = 0, int $timeBefore = 0)`:
+     fixed `$duration`-minute slots inside each agenda range. The stride between
+     slot starts is `duration + max(timeAfter, timeBefore)`.
+   - `DaySlotter(int $duration, int $step)`: ignores any agenda and produces
+     `duration`-minute slots every `step` minutes across the full 24h of each day
+     in the window (sliding window — slots may overlap when `step < duration`).
+
+## Conventions and gotchas
+
+- **Ranges and slots are always `League\Period\Period`** objects, not arrays.
+  Serialize with `->toIso8601()`. Tests compare on the ISO-8601 string form.
+- **Immutability**: all internal date math uses `Carbon`'s immutable variants
+  (`toImmutable()`, `CarbonImmutable`, `CarbonPeriodImmutable`). `AgendaSlotter`
+  and `DaySlotter` are `readonly class`es. Keep new code immutable.
+- **Timezones**: agendas compute in the timezone of the input `Carbon` instances.
+  `WeeklyScheduleAgenda` interprets `HH:MM` schedule times in that timezone and
+  clamps to the window. `Period::toIso8601()` renders in UTC (`Z`), so identical
+  wall-clock schedules in different timezones produce different UTC output — see
+  `WeeklyScheduleAgendaTest::possibleRangesWithTimeZone`.
+- **`hours_in_advance` is metadata only.** It is stored and exposed via
+  `hoursInAdvance()` but **not enforced** by the slotters — minimum-notice
+  filtering is the consumer's responsibility.
+- **`disable_all` IS enforced** inside `WeeklySchedule::forDay/forDate` (returns
+  `[]`), so a `WeeklyScheduleAgenda` over a disabled schedule yields no ranges.
+- **`HasAgenda` and `TimeBookable` are not used internally** — they exist for
+  consuming applications to implement on their own entities.
+- Validation errors are plain `\Exception` with descriptive messages; the unit
+  tests assert on those exact messages, so update tests if you change wording.
+
+## Commands
+
+```bash
+composer install            # install dependencies
+composer test               # run the PHPUnit suite (vendor/bin/phpunit)
+composer test-coverage      # run tests with HTML coverage report
+```
+
+PHPUnit is configured in `phpunit.xml.dist`. It is **strict**:
+`failOnRisky`, `failOnWarning`, and `failOnPhpunitDeprecation` are all enabled,
+and coverage metadata is enforced. Tests use PHPUnit attributes (`#[Test]`,
+`#[DataProvider]`), not docblock annotations.
+
+## Quality gates / CI
+
+- **GitHub Actions** (`.github/workflows/php.yml`) runs on push/PR to `master`
+  across PHP **8.4** and **8.5**: `composer validate` then `composer test`.
+- **Code style**: PSR-12 (`.styleci.yml` preset `psr12`). `.editorconfig`
+  enforces 4-space indent, LF line endings, UTF-8, trailing-whitespace trim, and
+  a final newline.
+- Versioning follows **SemVer**; do not break public APIs casually.
+
+## Working agreements
+
+- **English only.** This is an open-source project: all code, comments, commit
+  messages, PRs, and docs must be written in English.
+- **Add tests** for any behavior change — PRs without tests are not accepted
+  (see `CONTRIBUTING.md`). Prefer data-provider-driven tests like the existing
+  slotter tests.
+- Keep the library framework-agnostic — do not add framework dependencies.
+- Update `README.md` and `CHANGELOG.md` when behavior or the public API changes.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,273 @@
-# Very short description of the package
+# Bookables
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/puntodev/bookables.svg?style=flat-square)](https://packagist.org/packages/puntodev/bookables)
-[![Build Status](https://img.shields.io/travis/puntodev/bookables/master.svg?style=flat-square)](https://travis-ci.org/puntodev/bookables)
-[![Quality Score](https://img.shields.io/scrutinizer/g/puntodev/bookables.svg?style=flat-square)](https://scrutinizer-ci.com/g/puntodev/bookables)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/puntodev/bookables/php.yml?branch=master&style=flat-square)](https://github.com/puntodev/bookables/actions/workflows/php.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/puntodev/bookables.svg?style=flat-square)](https://packagist.org/packages/puntodev/bookables)
+[![License](https://img.shields.io/packagist/l/puntodev/bookables.svg?style=flat-square)](LICENSE.md)
 
-This is where your description should go. Try and limit it to a paragraph or two, and maybe throw in a mention of what PSRs you support to avoid any confusion with users and contributors.
+A small, **framework-agnostic** PHP library for computing **bookable availability and
+time slots**. You describe when something is available — with a recurring weekly
+schedule or a single date range — and Bookables turns that into concrete time ranges
+and ready-to-book slots for any window of dates.
+
+It's a pure domain library: no framework coupling, no database, no HTTP. Drop it into
+any PHP application (Laravel, Symfony, plain PHP, …) that needs to answer *"when can
+this resource be booked?"*. It builds on [`nesbot/carbon`](https://carbon.nesbot.com/)
+for date/time math and [`league/period`](https://period.thephpleague.com/) for the
+`Period` value object used to represent ranges and slots.
+
+## Requirements
+
+- PHP `>=8.4 <9.0`
+- `ext-json`
 
 ## Installation
 
-You can install the package via composer:
+Install via [Composer](https://getcomposer.org/):
 
 ```bash
 composer require puntodev/bookables
 ```
 
-## Usage
+## Concepts
 
-``` php
-// Usage description here
+The library is organized around a simple pipeline:
+
+```
+WeeklySchedule  ──▶  Agenda  ──▶  TimeSlotter  ──▶  bookable slots
+ (availability)     (concrete       (slices ranges     (Period[])
+                     date ranges)    into slots)
 ```
 
-### Testing
+| Piece | Responsibility |
+| --- | --- |
+| **`WeeklySchedule`** | A value object describing recurring weekly availability (per-day time ranges). JSON/array serializable, with validation. |
+| **`Agenda`** (contract) | `possibleRanges(from, to)` → the concrete `Period` ranges available within a date window. |
+| **`WeeklyScheduleAgenda`** | An `Agenda` backed by a `WeeklySchedule`. |
+| **`SingleDateRangeAgenda`** | An `Agenda` for one fixed start/end range. |
+| **`TimeSlotter`** (contract) | `makeSlotsForDates(start, end)` → the bookable slots (as `Period`s) within a window. |
+| **`AgendaSlotter`** | Slices an `Agenda`'s ranges into fixed-duration slots, with optional gaps before/after. |
+| **`DaySlotter`** | Produces sliding-window slots across the whole day (ignores any agenda). |
+| **`HasAgenda`** / **`TimeBookable`** (contracts) | Interfaces you implement on your own entities (e.g. a professional, room, or resource). |
 
-``` bash
+> All ranges and slots are returned as [`League\Period\Period`](https://period.thephpleague.com/5.0/period/)
+> objects. Call `->toIso8601()` (or any `Period` method) to inspect them.
+
+## Usage
+
+### 1. Define a weekly schedule
+
+A `WeeklySchedule` describes, for each day of the week, the time ranges during which
+the resource is available. Build one from an array or from JSON — both validate the
+input and throw an `Exception` if it's malformed.
+
+```php
+use Puntodev\Bookables\WeeklySchedule;
+
+$schedule = WeeklySchedule::fromArray([
+    'hours_in_advance' => 24,
+    'disable_all' => false,
+    'daily' => [
+        'Mon' => [
+            ['start' => '08:00', 'end' => '12:00'],
+            ['start' => '14:00', 'end' => '18:00'],
+        ],
+        'Tue' => [['start' => '09:00', 'end' => '17:00']],
+        'Wed' => [],
+        // ...Thu, Fri, Sat, Sun
+    ],
+]);
+```
+
+The JSON form (handy for persisting a schedule in a database column):
+
+```php
+$schedule = WeeklySchedule::fromJson(
+    '{"hours_in_advance": 24, "disable_all": false, "daily": {"Sun":[{"start":"14:00","end":"15:00"}]}}'
+);
+
+$schedule->toJson();   // serialize back to a JSON string
+$schedule->toArray();  // or to an array
+```
+
+There's also a ready-made sample schedule (Mon–Fri 08:00–12:00 & 14:00–18:00, Sat
+10:00–12:00):
+
+```php
+$schedule = WeeklySchedule::fromArray(WeeklySchedule::defaultWorkingHours());
+```
+
+#### Schedule JSON schema
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `daily` | object | Map of day-of-week (`Sun`, `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`) to a list of `{ "start": "HH:MM", "end": "HH:MM" }` ranges. `start` must be before `end`. |
+| `hours_in_advance` | int | Minimum booking notice, in hours. **Metadata only** — stored and exposed via `hoursInAdvance()`, but not enforced by the slotters (see notes below). |
+| `disable_all` | bool | When `true`, the schedule yields no availability regardless of `daily`. Optional, defaults to `false`. |
+
+### 2. Get available ranges from an agenda
+
+An `Agenda` turns availability into the concrete date ranges that fall inside a
+requested `[from, to]` window.
+
+```php
+use Carbon\CarbonImmutable;
+use Puntodev\Bookables\Agenda\WeeklyScheduleAgenda;
+
+$agenda = new WeeklyScheduleAgenda($schedule);
+
+$ranges = $agenda->possibleRanges(
+    CarbonImmutable::parse('2020-01-20'),
+    CarbonImmutable::parse('2020-01-21'),
+);
+
+foreach ($ranges as $range) {
+    echo $range->toIso8601(), PHP_EOL;
+    // 2020-01-20T08:00:00.000000Z/2020-01-20T12:00:00.000000Z
+    // 2020-01-20T14:00:00.000000Z/2020-01-20T18:00:00.000000Z
+    // ...
+}
+```
+
+For one-off availability that isn't weekly (e.g. a single open window), use
+`SingleDateRangeAgenda`. It returns the intersection of its fixed range with the
+requested window (or no range at all if they don't overlap):
+
+```php
+use Puntodev\Bookables\Agenda\SingleDateRangeAgenda;
+
+$agenda = new SingleDateRangeAgenda(
+    CarbonImmutable::parse('2020-01-20 09:00'),
+    CarbonImmutable::parse('2020-01-20 17:00'),
+);
+```
+
+### 3. Turn ranges into bookable slots
+
+A `TimeSlotter` slices ranges into the actual slots a user can book.
+
+**`AgendaSlotter`** produces fixed-duration slots inside each of an agenda's ranges:
+
+```php
+use Puntodev\Bookables\Slots\AgendaSlotter;
+
+// 30-minute slots, back to back
+$slotter = new AgendaSlotter($agenda, duration: 30);
+
+$slots = $slotter->makeSlotsForDates(
+    CarbonImmutable::parse('2020-01-23'),
+    CarbonImmutable::parse('2020-01-23'),
+);
+
+// 2020-01-23T08:00:00.000000Z/2020-01-23T08:30:00.000000Z
+// 2020-01-23T08:30:00.000000Z/2020-01-23T09:00:00.000000Z
+// ...
+```
+
+You can reserve a gap before and/or after each appointment (in minutes). The stride
+between slot starts becomes `duration + max(timeAfter, timeBefore)`:
+
+```php
+// 50-minute appointments with a 10-minute gap after each → slots every 60 minutes
+$slotter = new AgendaSlotter($agenda, duration: 50, timeAfter: 10);
+
+// 2020-01-23T08:00:00.000000Z/2020-01-23T08:50:00.000000Z
+// 2020-01-23T09:00:00.000000Z/2020-01-23T09:50:00.000000Z
+// ...
+```
+
+**`DaySlotter`** ignores agendas entirely and lays a sliding window of slots across
+the full 24 hours of each day — useful when availability is "any time" and you only
+care about duration and stepping. When `step` is smaller than `duration`, slots
+overlap.
+
+```php
+use Puntodev\Bookables\Slots\DaySlotter;
+
+// 30-minute slots starting every 15 minutes
+$slotter = new DaySlotter(duration: 30, step: 15);
+
+$slots = $slotter->makeSlotsForDates(
+    CarbonImmutable::parse('2020-01-23'),
+    CarbonImmutable::parse('2020-01-23'),
+);
+
+// 2020-01-23T00:00:00.000000Z/2020-01-23T00:30:00.000000Z
+// 2020-01-23T00:15:00.000000Z/2020-01-23T00:45:00.000000Z
+// 2020-01-23T00:30:00.000000Z/2020-01-23T01:00:00.000000Z
+// ...
+```
+
+### Timezones
+
+Agendas compute availability in the timezone of the `Carbon` instances you pass in.
+`WeeklyScheduleAgenda` interprets the schedule's `HH:MM` times in that timezone. Note
+that `Period::toIso8601()` renders in UTC (`Z`), so the same wall-clock schedule in
+different timezones produces different UTC output:
+
+```php
+$tz = 'Pacific/Auckland';
+$ranges = $agenda->possibleRanges(
+    CarbonImmutable::parse('2020-01-20', $tz),
+    CarbonImmutable::parse('2020-01-20', $tz),
+);
+// 08:00–12:00 Auckland time → 2020-01-19T19:00:00Z / 2020-01-19T23:00:00Z
+```
+
+### Modeling your own bookable entities
+
+The `HasAgenda` and `TimeBookable` contracts are there for your application to
+implement on its own models — for example, a professional or room that exposes an
+agenda:
+
+```php
+use Puntodev\Bookables\Contracts\Agenda;
+use Puntodev\Bookables\Contracts\HasAgenda;
+
+class Professional implements HasAgenda
+{
+    public function agenda(): Agenda
+    {
+        return new WeeklyScheduleAgenda($this->weeklySchedule());
+    }
+}
+```
+
+## Notes & caveats
+
+- **`hours_in_advance` is not enforced** by the slotters. It's carried as metadata
+  (available via `hoursInAdvance()`); filtering out slots that are too soon is the
+  consuming application's responsibility.
+- **`disable_all` is enforced** — a `WeeklyScheduleAgenda` over a disabled schedule
+  yields no ranges.
+- Ranges and slots are immutable `League\Period\Period` objects; all internal date
+  math uses Carbon's immutable variants.
+
+## Testing
+
+```bash
 composer test
 ```
 
-### Changelog
+Generate an HTML coverage report:
 
-Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
+```bash
+composer test-coverage
+```
+
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for what has changed recently.
 
 ## Contributing
 
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details. In short: keep the library
+framework-agnostic, write everything in English, and include tests with every change.
 
-### Security
+## Security
 
-If you discover any security related issues, please email mariano.goldman@puntodev.com.ar instead of using the issue tracker.
+If you discover any security-related issues, please email
+mariano.goldman@puntodev.com.ar instead of using the issue tracker.
 
 ## Credits
 
@@ -45,4 +275,4 @@ If you discover any security related issues, please email mariano.goldman@puntod
 
 ## License
 
-The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+The MIT License (MIT). Please see the [License File](LICENSE.md) for more information.


### PR DESCRIPTION
## Summary

Documentation-only change. No code or behavior is modified.

- **README.md** — replaces the leftover skeleton template with real documentation:
  - Project overview (framework-agnostic availability/slotting library on top of Carbon + league/period).
  - Requirements and installation.
  - The `WeeklySchedule → Agenda → TimeSlotter → slots` pipeline, with a concepts table.
  - Runnable usage examples (weekly schedule, `WeeklyScheduleAgenda`, `SingleDateRangeAgenda`, `AgendaSlotter` with before/after gaps, `DaySlotter`), all drawn from the existing test suite.
  - The `WeeklySchedule` JSON schema, timezone behavior, and caveats (`hours_in_advance` is metadata only; `disable_all` is enforced).
  - Updated build badge from Travis to GitHub Actions.
- **AGENTS.md** — new file documenting the architecture, repo layout, conventions/gotchas, commands, CI/quality gates, and contributor working agreements (English-only, tests required, framework-agnostic).

## Testing

Not applicable — docs only. The full suite (37 tests) was run locally and passes on PHP 8.4 to confirm the documented examples reflect real behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)