### PR TITLE
Automate changelog updates from GitHub releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+# Configures GitHub's "Generate release notes" button.
+# Pull requests are grouped by their labels; the catch-all category ensures
+# every merged PR shows up even when it is unlabeled.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: 🛡️ Security
+      labels:
+        - security
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 🧰 Maintenance & Dependencies
+      labels:
+        - chore
+        - dependencies
+        - maintenance
+    - title: 📚 Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,34 @@
+name: Update Changelog
+
+# When a (non-prerelease) GitHub Release is published, write its notes into
+# CHANGELOG.md under the released version and commit the result back to master.
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v5
+        with:
+          ref: master
+          persist-credentials: true
+
+      - name: Update CHANGELOG
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.tag_name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          branch: master
+          commit_message: "docs: update CHANGELOG for ${{ github.event.release.tag_name }}"
+          file_pattern: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,130 +5,93 @@ All notable changes to `bookables` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Released entries below are maintained automatically from the GitHub release notes
+(see `.github/workflows/update-changelog.yml`); the `Unreleased` section tracks the
+range of changes on `master` that have not been released yet.
+
 ## [Unreleased]
 
-### Security
-
-- Cap requested date ranges to avoid unbounded slot generation (denial-of-service).
-  `WeeklyScheduleAgenda`, `AgendaSlotter` and `DaySlotter` now take an optional
-  `maxDays` argument (default `366`, `0` disables) and throw
-  `Puntodev\Bookables\Exceptions\DateRangeTooLargeException` when exceeded.
-- Reject non-positive `duration`/`step` (and negative `timeAfter`/`timeBefore`) in
-  the slotters with `InvalidArgumentException`, preventing degenerate zero-interval
-  loops.
-- Validate schedule times strictly as a time of day (`HH:MM` or `HH:MM:SS`,
-  `00:00`–`23:59`), rejecting relative expressions such as `now` or `+1 day`.
-- `WeeklySchedule::fromJson()` now throws an `Exception` on malformed or non-object
-  JSON instead of a `TypeError`.
-
-### Changed
-
-- Support Laravel 13, drop Laravel 12, and update dependencies (#25).
-
-### Documentation
-
-- Add a README usage guide and `AGENTS.md` (#26).
-
-## [4.1.2] - 2026-03-07
+## v4.1.2 - 2026-03-07
 
 - Update dependencies (#24).
 
-## [4.1.1] - 2025-11-22
+## v4.1.1 - 2025-11-22
 
 - Update dependencies (#23).
 
-## [4.1.0] - 2025-11-09
+## v4.1.0 - 2025-11-09
 
 - Support for PHP 8.3 and newer (#22).
 
-## [4.0.1] - 2025-02-16
+## v4.0.1 - 2025-02-16
 
 - All interfaces take and return immutable Carbon dates and periods (#21).
 
-## [4.0.0] - 2025-02-05
+## v4.0.0 - 2025-02-05
 
 - Make the library compatible with PHP 8.3 and later (#20).
 - Update libraries (#19).
 
-## [3.1.0] - 2023-03-18
+## v3.1.0 - 2023-03-18
 
 - Upgrade to PHPUnit 10 (#17).
 
-## [3.0.0] - 2022-12-14
+## v3.0.0 - 2022-12-14
 
 - Make the library compatible with PHP 8.2 and later (#16).
 
-## [2.6.0] - 2022-04-11
+## v2.6.0 - 2022-04-11
 
 - Remove the production dependency on `nunomaduro/collision` (#15).
 
-## [2.5.0] - 2021-11-22
+## v2.5.0 - 2021-11-22
 
 - Redesign the agenda slotter (#14).
 - Add a day slotter (#13).
 - Segregate the slotter/agenda interfaces (#12).
 
-## [2.4.0] - 2021-11-22
+## v2.4.0 - 2021-11-22
 
 - Add the agenda slotter (#11).
 - Update libraries (#10).
 
-## [2.3.0] - 2021-06-11
+## v2.3.0 - 2021-06-11
 
 - Add an option to align (or not) minutes to the stepping (#9).
 
-## [2.2.0] - 2021-04-17
+## v2.2.0 - 2021-04-17
 
 - Convert a schedule to array and to JSON (#8).
 
-## [2.1.0] - 2021-04-09
+## v2.1.0 - 2021-04-09
 
 - Remove the unused `Bookable` interface (#7).
 - Require PHP 8+ and update libraries (#6).
 
-## [2.0.0] - 2021-03-14
+## v2.0.0 - 2021-03-14
 
 - Add a field to temporarily override a schedule and disable the agenda without
   deleting it (#5).
 - Update libraries (#4).
 
-## [1.0.0] - 2020-11-26
+## v1.0.0 - 2020-11-26
 
 - Support for PHP 8 (#3).
 
-## [0.0.4] - 2020-09-02
+## v0.0.4 - 2020-09-02
 
 - Add contracts, agenda, and time slots (#2).
 
-## [0.0.3] - 2020-09-02
+## v0.0.3 - 2020-09-02
 
 - Add the weekly schedule class (#1).
 
-## [0.0.2] - 2020-09-01
+## v0.0.2 - 2020-09-01
 
 - Restrict the supported runtime to PHP 7.4.
 
-## [0.0.1] - 2020-09-01
+## v0.0.1 - 2020-09-01
 
 - Initial release.
 
 [Unreleased]: https://github.com/puntodev/bookables/compare/v4.1.2...HEAD
-[4.1.2]: https://github.com/puntodev/bookables/compare/v4.1.1...v4.1.2
-[4.1.1]: https://github.com/puntodev/bookables/compare/v4.1.0...v4.1.1
-[4.1.0]: https://github.com/puntodev/bookables/compare/v4.0.1...v4.1.0
-[4.0.1]: https://github.com/puntodev/bookables/compare/v4.0.0...v4.0.1
-[4.0.0]: https://github.com/puntodev/bookables/compare/v3.1.0...v4.0.0
-[3.1.0]: https://github.com/puntodev/bookables/compare/v3.0.0...v3.1.0
-[3.0.0]: https://github.com/puntodev/bookables/compare/v2.6.0...v3.0.0
-[2.6.0]: https://github.com/puntodev/bookables/compare/v2.5.0...v2.6.0
-[2.5.0]: https://github.com/puntodev/bookables/compare/v2.4.0...v2.5.0
-[2.4.0]: https://github.com/puntodev/bookables/compare/v2.3.0...v2.4.0
-[2.3.0]: https://github.com/puntodev/bookables/compare/v2.2.0...v2.3.0
-[2.2.0]: https://github.com/puntodev/bookables/compare/v2.1.0...v2.2.0
-[2.1.0]: https://github.com/puntodev/bookables/compare/v2.0.0...v2.1.0
-[2.0.0]: https://github.com/puntodev/bookables/compare/v1.0.0...v2.0.0
-[1.0.0]: https://github.com/puntodev/bookables/compare/v0.0.4...v1.0.0
-[0.0.4]: https://github.com/puntodev/bookables/compare/v0.0.3...v0.0.4
-[0.0.3]: https://github.com/puntodev/bookables/compare/v0.0.2...v0.0.3
-[0.0.2]: https://github.com/puntodev/bookables/compare/v0.0.1...v0.0.2
-[0.0.1]: https://github.com/puntodev/bookables/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -282,6 +282,22 @@ composer test-coverage
 
 Please see [CHANGELOG](CHANGELOG.md) for what has changed recently.
 
+## Releasing
+
+Releases are cut from GitHub and the changelog is kept in sync automatically:
+
+1. Merge the pull requests you want to ship into `master`. Label them so the notes
+   group nicely (`security`, `enhancement`, `bug`, `dependencies`, `documentation`);
+   grouping is configured in [`.github/release.yml`](.github/release.yml).
+2. On GitHub, go to **Releases → Draft a new release**, create a `vX.Y.Z` tag
+   following [SemVer](https://semver.org/), and click **Generate release notes**.
+3. **Publish** the release. Packagist picks up the new tag, and the
+   [`update-changelog.yml`](.github/workflows/update-changelog.yml) workflow writes
+   the release notes into `CHANGELOG.md` and commits them back to `master`.
+
+The `Unreleased` section in the changelog is just an anchor — release notes flow
+from the published GitHub release, so there is no changelog to edit by hand.
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details. In short: keep the library


### PR DESCRIPTION
Follow-up to #27. Sets up the **GitHub-native release flow**: you create the release in the GitHub UI, and CI keeps `CHANGELOG.md` in sync. No commit-message convention required; your current PR-based workflow stays the same.

## How releasing works after this

1. Merge PRs into `master`, labeled so the notes group nicely (`security`, `enhancement`, `bug`, `dependencies`, `documentation`).
2. **Releases → Draft a new release** → new `vX.Y.Z` tag → **Generate release notes** → **Publish**.
3. The `update-changelog.yml` workflow writes those notes into `CHANGELOG.md` under `## vX.Y.Z - <date>` and commits back to `master`. Packagist picks up the tag automatically.

## Files

- **`.github/release.yml`** — groups GitHub's auto-generated notes by PR label (Security / Features / Bug Fixes / Maintenance & Dependencies / Documentation), with a `*` catch-all so unlabeled PRs still show. Excludes `dependabot` and `ignore-for-release`.
- **`.github/workflows/update-changelog.yml`** — on `release: released`, runs `stefanzweifel/changelog-updater-action@v1` then commits via `stefanzweifel/git-auto-commit-action@v7` (`permissions: contents: write`).
- **`CHANGELOG.md`** — headings normalized to `## vX.Y.Z - <date>` (matches what the action emits), `Unreleased` kept as an anchor with its compare link. The previously hand-written `Unreleased` bullets are intentionally dropped: at the next release, GitHub's auto-generated notes will capture the already-merged PRs (#25, #26, #27) since v4.1.2, so nothing is lost — and keeping them would duplicate against the generated section.
- **`README.md`** — documents the release process.

## Notes / decisions

- The action uses `latest-version` both as the heading text **and** in the `Unreleased` compare URL, so it must equal the real tag (`vX.Y.Z`). That's why headings carry the `v` prefix.
- Prereleases don't touch the changelog (`types: [released]`, not `published`).

## Try it
Verified YAML parses; the workflow only runs on a published release, so the first real run will be the next release you cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)