### PR TITLE
Backfill v5.0.0 changelog and enable PAT-based sync

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: master
+          # Admin PAT so the changelog commit can be pushed to the protected
+          # master branch (the default GITHUB_TOKEN is rejected by branch
+          # protection). Requires enforce_admins to be disabled on master.
+          token: ${{ secrets.RELEASE_TOKEN }}
           persist-credentials: true
 
       - name: Update CHANGELOG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ range of changes on `master` that have not been released yet.
 
 ## [Unreleased]
 
+## v5.0.0 - 2026-06-13
+
+### 🛡️ Security
+
+- Harden scheduling against unbounded ranges and invalid input (#27).
+  **BREAKING:** date ranges are now capped (default 366 days, `DateRangeTooLargeException`)
+  and schedule times must be a strict time of day (`HH:MM`/`HH:MM:SS`); previously
+  accepted values such as non-padded hours (`8:00`) or relative strings (`now`) are
+  rejected.
+
+### 🧰 Maintenance & Dependencies
+
+- Support Laravel 13, drop Laravel 12, and update dependencies (#25).
+
+### 📚 Documentation
+
+- Add a README usage guide and `AGENTS.md` (#26).
+
+### Other Changes
+
+- Automate changelog updates from GitHub releases (#28).
+
 ## v4.1.2 - 2026-03-07
 
 - Update dependencies (#24).
@@ -94,4 +116,4 @@ range of changes on `master` that have not been released yet.
 
 - Initial release.
 
-[Unreleased]: https://github.com/puntodev/bookables/compare/v4.1.2...HEAD
+[Unreleased]: https://github.com/puntodev/bookables/compare/v5.0.0...HEAD


### PR DESCRIPTION
## Why

The `v5.0.0` release **did** trigger `update-changelog.yml` and it generated the changelog correctly — but the final push to `master` was **rejected by branch protection**:

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - 2 of 2 required status checks are expected.
```

`master` uses classic branch protection with `enforce_admins: true` + required status checks (PHP 8.4 / 8.5). The default `GITHUB_TOKEN` (github-actions[bot]) can't push directly because it can't satisfy those checks. So `CHANGELOG.md` was never updated.

## What this PR does

- **Backfills the `v5.0.0` entry** into `CHANGELOG.md` (one-off, since that release already happened) and points the `Unreleased` compare link at `v5.0.0`.
- **Updates `update-changelog.yml`** to check out `master` with an admin PAT (`secrets.RELEASE_TOKEN`) so future releases can push the changelog commit.

## ⚠️ Required manual steps before the next release (your side)

1. **Create a PAT** owned by an admin (you):
   - Fine-grained → repo `puntodev/bookables` → **Contents: Read and write**.
2. **Add it as a repo secret** named `RELEASE_TOKEN`
   (`Settings → Secrets and variables → Actions`).
3. **Disable `enforce_admins`** on `master` so the admin PAT can bypass the required
   status checks on a direct push:
   ```
   gh api -X DELETE repos/puntodev/bookables/branches/master/protection/enforce_admins
   ```
   (Reversible: `PUT` the same endpoint to re-enable.)

Without step 3, even an admin PAT is blocked. With it, the bot push bypasses the checks while everything else stays protected (force-pushes/deletions still blocked, linear history enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)